### PR TITLE
Fixing parse error in gemspec

### DIFF
--- a/query-matchers.gemspec
+++ b/query-matchers.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = ''
   spec.description   = ''
-  spec.homepage      = ''
+  spec.homepage      = 'https://github.com/Gusto/ar-query-matchers/'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
Modern versions of Ruby attempt to run the  through URI.parse.