### PR TITLE
Running rubocop as part of CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,9 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
+RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: %i[rubocop spec]


### PR DESCRIPTION
This'll keep us from having to chase down Rubocop violations that creep in later