### PR TITLE
Add field counters to allow you to check if a field was referenced

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.2']
+        ruby: ['2.7', '3.2', '3.3']
         appraisal: ["rails-6", "rails-7"]
     steps:
     - uses: actions/checkout@v1
@@ -19,7 +19,15 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Build and test with Rake
+    - name: Build and test with Rake (Ruby 2.7 only)
+      if: ${{ matrix.ruby == '2.7' }}
+      run: |
+        gem install bundler -v 2.4.22
+        bundle install --jobs 4 --retry 3
+        bundle exec appraisal install
+        bundle exec appraisal ${{ matrix.appraisal }} rake
+    - name: Build and test with Rake (Ruby 3.2+ only)
+      if: ${{ matrix.ruby != '2.7' }}
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.2', '3.3']
+        ruby: ['3.2', '3.3']
         appraisal: ["rails-6", "rails-7"]
     steps:
     - uses: actions/checkout@v1
@@ -19,15 +19,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Build and test with Rake (Ruby 2.7 only)
-      if: ${{ matrix.ruby == '2.7' }}
-      run: |
-        gem install bundler -v 2.4.22
-        bundle install --jobs 4 --retry 3
-        bundle exec appraisal install
-        bundle exec appraisal ${{ matrix.appraisal }} rake
-    - name: Build and test with Rake (Ruby 3.2+ only)
-      if: ${{ matrix.ruby != '2.7' }}
+    - name: Build and test with Rake
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3

--- a/lib/ar_query_matchers.rb
+++ b/lib/ar_query_matchers.rb
@@ -349,7 +349,7 @@ module ArQueryMatchers
         end
       end
 
-      def filter_model_names(expected, subset, values_only)
+      def filter_model_names(subset, values_only)
         all_model_names = expected.keys + @query_stats.queries.keys
         if values_only
           all_model_names.reject { |key| reject_record(subset, expected, key) }.uniq
@@ -359,10 +359,9 @@ module ArQueryMatchers
       end
 
       def expectation_failed_message(crud_operation, values_only: false, subset: false)
-        if values_only
-          expected = expected.transform_values { |v| v.is_a(Array) ? v : [v] }
-        end
-        model_names_with_wrong_count = filter_model_names(expected, subset, values_only)
+        expected.transform_values { |v| v.is_a(Array) ? v : [v] } if values_only
+
+        model_names_with_wrong_count = filter_model_names(subset, values_only)
         "Expected ActiveRecord to #{crud_operation} #{expected}, got #{values_only ? @query_stats.query_values : @query_stats.query_counts}\n"\
           "Expectations that differed:\n#{difference(model_names_with_wrong_count, values_only: values_only).join("\n")}\n\nWhere unexpected queries came from:\n\n#{source_lines(model_names_with_wrong_count).join("\n")}"
       end

--- a/lib/ar_query_matchers.rb
+++ b/lib/ar_query_matchers.rb
@@ -401,8 +401,9 @@ module ArQueryMatchers
 
       def expectation_failed_message(crud_operation, show_values: false, subset: false, ignore_missing: false)
         model_names_with_wrong_count = filter_model_names(subset, show_values, ignore_missing)
-        "Expected ActiveRecord to #{crud_operation} #{expected}, got #{show_values ? @query_stats.query_values : @query_stats.query_counts}\n"\
-          "Expectations that differed:\n#{difference(model_names_with_wrong_count, show_values: show_values).join("\n")}\n\nWhere unexpected queries came from:\n\n#{source_lines(model_names_with_wrong_count).join("\n")}"
+        message = "Expected ActiveRecord to #{crud_operation} #{expected}, got #{show_values ? @query_stats.query_values : @query_stats.query_counts}\n"
+        message += "Expectations that differed:\n#{difference(model_names_with_wrong_count, show_values: show_values).join("\n")}" if show_values
+        message += "\n\nWhere unexpected queries came from:\n\n#{source_lines(model_names_with_wrong_count).join("\n")}"
       end
     end
   end

--- a/lib/ar_query_matchers.rb
+++ b/lib/ar_query_matchers.rb
@@ -403,7 +403,7 @@ module ArQueryMatchers
         model_names_with_wrong_count = filter_model_names(subset, show_values, ignore_missing)
         message = "Expected ActiveRecord to #{crud_operation} #{expected}, got #{show_values ? @query_stats.query_values : @query_stats.query_counts}\n"
         message += "Expectations that differed:\n#{difference(model_names_with_wrong_count, show_values: show_values).join("\n")}" if show_values
-        message += "\n\nWhere unexpected queries came from:\n\n#{source_lines(model_names_with_wrong_count).join("\n")}"
+        message + "\n\nWhere unexpected queries came from:\n\n#{source_lines(model_names_with_wrong_count).join("\n")}"
       end
     end
   end

--- a/lib/ar_query_matchers/queries/field_counter.rb
+++ b/lib/ar_query_matchers/queries/field_counter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative './query_counter'
+require_relative './field_name'
+require_relative './query_filter'
+
+module ArQueryMatchers
+  module Queries
+    # A specialized QueryCounter for "any action that involves field IDs".
+    # For more information, see the QueryCounter class.
+    class FieldCounter
+      def self.instrument(&block)
+        QueryCounter.new(FieldCounterFilter.new).instrument(&block)
+      end
+
+      class FieldCounterFilter < Queries::QueryFilter
+        # We need to look for a few things:
+        # Anything with ` {field} = {value}` (this could be a select, update, delete)
+        MODEL_FIELDS_PATTERN = /\.`(?<field_name>[\w]+)` = (?<field_value>[\w"`]+)/
+
+        # Anything with ` {field} IN ({value})` (this could be a select, update, delete)
+        MODEL_FIELDS_IN_PATTERN = /\.`(?<field_name>[\w]+)` IN \((?<field_value>[\w"`]+)\)/
+
+        # Anything with `, field,` in an INSERT (we need to check the values)
+        MODEL_INSERT_PATTERN = /INSERT INTO (?<table_name>[^`"]+) ... VALUES .../
+
+        def cleanup(value)
+          cleaned_value = value.gsub '`', ''
+
+          # If this is an integer, we'll cast it automatically
+          if cleaned_value == value
+            cleaned_value = value.to_i
+          end
+
+          cleaned_value
+        end
+
+        def filter_map(name, sql)
+          # We need to look for a few things:
+          #   - Anything with ` {field} = ` (this could be a select, update, delete)
+          #   - Anything with `, field,` in an INSERT (we need to check the values)
+          select_field_query = sql.match(MODEL_FIELDS_PATTERN)
+          if sql.match(/INSERT/)
+            debugger
+          end
+
+          FieldName.new(select_field_query[:field_name], cleanup(select_field_query[:field_value])) if select_field_query
+        end
+      end
+    end
+  end
+end

--- a/lib/ar_query_matchers/queries/field_counter.rb
+++ b/lib/ar_query_matchers/queries/field_counter.rb
@@ -13,13 +13,14 @@ module ArQueryMatchers
         QueryCounter.new(FieldCounterFilter.new).instrument(&block)
       end
 
+      # Filters queries for counting purposes
       class FieldCounterFilter < Queries::QueryFilter
         # We need to look for a few things:
         # Anything with ` {field} = {value}` (this could be a select, update, delete)
-        MODEL_FIELDS_PATTERN = /\.`(?<field_name>[\w]+)` = (?<field_value>[\w"`]+)/
+        MODEL_FIELDS_PATTERN = /\.`(?<field_name>\w+)` = (?<field_value>[\w"`]+)/
 
         # Anything with ` {field} IN ({value})` (this could be a select, update, delete)
-        MODEL_FIELDS_IN_PATTERN = /\.`(?<field_name>[\w]+)` IN \((?<field_value>[\w"`]+)\)/
+        MODEL_FIELDS_IN_PATTERN = /\.`(?<field_name>\w+)` IN \((?<field_value>[\w"`]+)\)/
 
         # Anything with `, field,` in an INSERT (we need to check the values)
         MODEL_INSERT_PATTERN = /INSERT INTO (?<table_name>[^`"]+) ... VALUES .../
@@ -28,21 +29,17 @@ module ArQueryMatchers
           cleaned_value = value.gsub '`', ''
 
           # If this is an integer, we'll cast it automatically
-          if cleaned_value == value
-            cleaned_value = value.to_i
-          end
+          cleaned_value = value.to_i if cleaned_value == value
 
           cleaned_value
         end
 
-        def filter_map(name, sql)
+        def filter_map(_name, sql)
           # We need to look for a few things:
           #   - Anything with ` {field} = ` (this could be a select, update, delete)
           #   - Anything with `, field,` in an INSERT (we need to check the values)
           select_field_query = sql.match(MODEL_FIELDS_PATTERN)
-          if sql.match(/INSERT/)
-            debugger
-          end
+          # debugger if sql.match(/INSERT/)
 
           FieldName.new(select_field_query[:field_name], cleanup(select_field_query[:field_value])) if select_field_query
         end

--- a/lib/ar_query_matchers/queries/field_counter.rb
+++ b/lib/ar_query_matchers/queries/field_counter.rb
@@ -40,6 +40,7 @@ module ArQueryMatchers
           #   - Anything with `, field,` in an INSERT (we need to check the values)
           select_field_query = sql.match(MODEL_FIELDS_PATTERN)
           # debugger if sql.match(/INSERT/)
+          # TODO: MODEL_FIELDS_IN_PATTERN and MODEL_INSERT_PATTERN need to be handled
 
           FieldName.new(select_field_query[:field_name], cleanup(select_field_query[:field_value])) if select_field_query
         end

--- a/lib/ar_query_matchers/queries/field_name.rb
+++ b/lib/ar_query_matchers/queries/field_name.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ArQueryMatchers
+  module Queries
+    # An instance of this class is one of the values that could be returned from the QueryFilter#filter_map.
+    # its accepts a name of an ActiveRecord model, for example: 'Company'.
+    class FieldName
+      attr_reader(:model_name)
+      attr_reader(:model_value)
+
+      def initialize(model_name, model_value)
+        @model_name = model_name
+        @model_value = model_value
+      end
+    end
+  end
+end

--- a/lib/ar_query_matchers/queries/field_name.rb
+++ b/lib/ar_query_matchers/queries/field_name.rb
@@ -3,7 +3,7 @@
 module ArQueryMatchers
   module Queries
     # An instance of this class is one of the values that could be returned from the QueryFilter#filter_map.
-    # its accepts a name of an ActiveRecord model, for example: 'Company'.
+    # it accepts a name of an ActiveRecord model, for example: 'Company'.
     class FieldName
       attr_reader(:model_name, :model_value)
 

--- a/lib/ar_query_matchers/queries/field_name.rb
+++ b/lib/ar_query_matchers/queries/field_name.rb
@@ -5,8 +5,7 @@ module ArQueryMatchers
     # An instance of this class is one of the values that could be returned from the QueryFilter#filter_map.
     # its accepts a name of an ActiveRecord model, for example: 'Company'.
     class FieldName
-      attr_reader(:model_name)
-      attr_reader(:model_value)
+      attr_reader(:model_name, :model_value)
 
       def initialize(model_name, model_value)
         @model_name = model_name

--- a/lib/ar_query_matchers/queries/load_counter.rb
+++ b/lib/ar_query_matchers/queries/load_counter.rb
@@ -17,7 +17,7 @@ module ArQueryMatchers
       class LoadQueryFilter < Queries::QueryFilter
         # Matches named SQL operations like the following:
         # 'User Load'
-        MODEL_LOAD_PATTERN = /\A(?<model_name>[\w:]+) (Load|Exists)\Z/
+        MODEL_LOAD_PATTERN = /\A(?<field_name>[\w:]+)/
 
         # Matches unnamed SQL operations like the following:
         # "SELECT COUNT(*) FROM `users` ..."

--- a/lib/ar_query_matchers/queries/load_counter.rb
+++ b/lib/ar_query_matchers/queries/load_counter.rb
@@ -27,7 +27,7 @@ module ArQueryMatchers
           # First check for a `SELECT * FROM` query that ActiveRecord has
           # helpfully named for us in the payload
           match = name.match(MODEL_LOAD_PATTERN)
-          return ModelName.new(match[:model_name]) if match and match.names.include? :model_name
+          return ModelName.new(match[:model_name]) if match&.names&.include? :model_name
 
           # Fall back to pattern-matching on the table name in a COUNT and looking
           # up the table name from ActiveRecord's loaded descendants.

--- a/lib/ar_query_matchers/queries/load_counter.rb
+++ b/lib/ar_query_matchers/queries/load_counter.rb
@@ -27,7 +27,7 @@ module ArQueryMatchers
           # First check for a `SELECT * FROM` query that ActiveRecord has
           # helpfully named for us in the payload
           match = name.match(MODEL_LOAD_PATTERN)
-          return ModelName.new(match[:model_name]) if match
+          return ModelName.new(match[:model_name]) if match and match.names.include? :model_name
 
           # Fall back to pattern-matching on the table name in a COUNT and looking
           # up the table name from ActiveRecord's loaded descendants.

--- a/lib/ar_query_matchers/queries/query_counter.rb
+++ b/lib/ar_query_matchers/queries/query_counter.rb
@@ -82,7 +82,7 @@ module ArQueryMatchers
       MARGINALIA_SQL_COMMENT_PATTERN = %r{/*line:(?<line>.*)'*/}
       private_constant :MARGINALIA_SQL_COMMENT_PATTERN
 
-      def add_to_query(queries, payload, model_obj, finish, start)
+      def add_to_query(queries, model_name, payload, model_obj, finish, start)
         comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
         queries[model_name][:lines] << comment[:line] if comment
         queries[model_name][:count] += 1
@@ -100,7 +100,7 @@ module ArQueryMatchers
           model_obj = @query_filter.filter_map(payload[:name] || '', payload[:sql] || '')
           model_name = model_obj&.model_name
 
-          add_to_query(queries, payload, model_obj, finish, start) if model_name
+          add_to_query(queries, model_name, payload, model_obj, finish, start) if model_name
         end
       end
     end

--- a/lib/ar_query_matchers/queries/query_counter.rb
+++ b/lib/ar_query_matchers/queries/query_counter.rb
@@ -82,7 +82,8 @@ module ArQueryMatchers
       MARGINALIA_SQL_COMMENT_PATTERN = %r{/*line:(?<line>.*)'*/}
       private_constant :MARGINALIA_SQL_COMMENT_PATTERN
 
-      def add_to_query(queries, model_name, payload, model_obj, finish, start)
+      def add_to_query(queries, payload, model_obj, finish, start)
+        model_name = model_obj&.model_name
         comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
         queries[model_name][:lines] << comment[:line] if comment
         queries[model_name][:count] += 1
@@ -100,7 +101,7 @@ module ArQueryMatchers
           model_obj = @query_filter.filter_map(payload[:name] || '', payload[:sql] || '')
           model_name = model_obj&.model_name
 
-          add_to_query(queries, model_name, payload, model_obj, finish, start) if model_name
+          add_to_query(queries, payload, model_obj, finish, start) if model_name
         end
       end
     end

--- a/lib/ar_query_matchers/queries/query_counter.rb
+++ b/lib/ar_query_matchers/queries/query_counter.rb
@@ -87,7 +87,7 @@ module ArQueryMatchers
         comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
         queries[model_name][:lines] << comment[:line] if comment
         queries[model_name][:count] += 1
-        queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value) and !queries[model_name][:values].include?(model_obj&.model_value)
+        queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value) && !queries[model_name][:values].include?(model_obj&.model_value)
         queries[model_name][:time] += (finish - start).round(6) # Round to microseconds
       end
 

--- a/lib/ar_query_matchers/queries/query_counter.rb
+++ b/lib/ar_query_matchers/queries/query_counter.rb
@@ -82,6 +82,14 @@ module ArQueryMatchers
       MARGINALIA_SQL_COMMENT_PATTERN = %r{/*line:(?<line>.*)'*/}
       private_constant :MARGINALIA_SQL_COMMENT_PATTERN
 
+      def add_to_query(queries, payload, model_obj, finish, start)
+        comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
+        queries[model_name][:lines] << comment[:line] if comment
+        queries[model_name][:count] += 1
+        queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value)
+        queries[model_name][:time] += (finish - start).round(6) # Round to microseconds
+      end
+
       def to_proc(queries)
         lambda do |_name, start, finish, _message_id, payload|
           return if payload[:cached]
@@ -92,13 +100,7 @@ module ArQueryMatchers
           model_obj = @query_filter.filter_map(payload[:name] || '', payload[:sql] || '')
           model_name = model_obj&.model_name
 
-          if model_name
-            comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
-            queries[model_name][:lines] << comment[:line] if comment
-            queries[model_name][:count] += 1
-            queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value)
-            queries[model_name][:time] += (finish - start).round(6) # Round to microseconds
-          end
+          add_to_query(queries, payload, model_obj, finish, start) if model_name
         end
       end
     end

--- a/lib/ar_query_matchers/queries/query_counter.rb
+++ b/lib/ar_query_matchers/queries/query_counter.rb
@@ -87,7 +87,7 @@ module ArQueryMatchers
         comment = payload[:sql].match(MARGINALIA_SQL_COMMENT_PATTERN)
         queries[model_name][:lines] << comment[:line] if comment
         queries[model_name][:count] += 1
-        queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value)
+        queries[model_name][:values].append(model_obj&.model_value) if model_obj.respond_to?(:model_value) and !queries[model_name][:values].include?(model_obj&.model_value)
         queries[model_name][:time] += (finish - start).round(6) # Round to microseconds
       end
 

--- a/spec/ar_query_matchers/mock_data_model.rb
+++ b/spec/ar_query_matchers/mock_data_model.rb
@@ -3,6 +3,7 @@
 # @mission Infrastructure
 # @team DEx
 
+require 'logger'
 require 'active_record'
 
 RSpec.shared_context('mock_data_model') do


### PR DESCRIPTION
Summary
====
The intent of this PR is to enable field counters and create two helpers: `query_by_field` and `query_by_field_at_least`. When trying to analyze changes to models, we may want to check if there's expected changes by looking for specific fields. In doing so, we can use this to test for changes by using the helpers above:

- `query_by_field` matches the changes in fields to the expected changes exactly. If they do not match, the test will fail.
- `query_by_field_at_least` matches the changes in fields to the expected changes, but only matches the fields the expected changes have mentioned. For example, if fields A and B are changed but we only expect field A to change, if the actual values and the expected values for A are the same, we'll pass this test - regardless of what field B changes have been made, if any.
- `query_by_field_at_least_ignore_notfound` matches the changes in fields to the expected changes, similarly to `query_by_field_at_least`, but when checking for changes to field A, if the expected changes are included in the actual changes but not the same, we will pass this test. For example, if field A is expected to contain the values [1,2] and the actual values are [1,2,3], `query_by_field_at_least_ignore_notfound` will succeed but `query_by_field_at_least` would fail.