### PR TITLE
Adds a Destroy counter

### DIFF
--- a/lib/ar_query_matchers.rb
+++ b/lib/ar_query_matchers.rb
@@ -3,6 +3,7 @@
 require 'ar_query_matchers/queries/create_counter'
 require 'ar_query_matchers/queries/load_counter'
 require 'ar_query_matchers/queries/update_counter'
+require 'ar_query_matchers/queries/destroy_counter'
 require 'bigdecimal'
 
 module ArQueryMatchers
@@ -221,6 +222,50 @@ module ArQueryMatchers
 
         def failure_text
           no_queries_fail_message('update')
+        end
+      end
+    end
+
+    class DestroyModels
+      # The following will succeed:
+      #
+      #    expect {
+      #       WcRiskClass.last.update_attributes(id: 9999)
+      #    }.to only_destroy_models(
+      #       'WcRiskClass' => 1,
+      #    )
+      #
+      RSpec::Matchers.define(:only_destroy_models) do |expected = {}|
+        include MatcherConfiguration
+        include MatcherErrors
+
+        match do |block|
+          @query_stats = Queries::UpdateCounter.instrument(&block)
+          Utility.remove_superfluous_expectations(expected) == @query_stats.query_counts
+        end
+
+        def failure_text
+          expectation_failed_message('destroy')
+        end
+      end
+
+      # The following will not succeed because the code destroys models:
+      #
+      #    expect {
+      #       WcRiskClass.last.destroy_attributes(id: 9999)
+      #    }.to not_destroy_any_models
+      #
+      RSpec::Matchers.define(:not_destroy_any_models) do
+        include MatcherConfiguration
+        include MatcherErrors
+
+        match do |block|
+          @query_stats = Queries::UpdateCounter.instrument(&block)
+          @query_stats.query_counts.empty?
+        end
+
+        def failure_text
+          no_queries_fail_message('destroy')
         end
       end
     end

--- a/lib/ar_query_matchers/queries/destroy_counter.rb
+++ b/lib/ar_query_matchers/queries/destroy_counter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative './query_counter'
+require_relative './table_name'
+require_relative './model_name'
+require_relative './query_filter'
+
+module ArQueryMatchers
+  module Queries
+    # A specialized QueryCounter for "loads".
+    # For more information, see the QueryCounter class.
+    class DestroyCounter
+      def self.instrument(&block)
+        QueryCounter.new(DestroyQueryFilter.new).instrument(&block)
+      end
+
+      class DestroyQueryFilter < Queries::QueryFilter
+        # Matches named SQL operations like the following:
+        # 'User Destroy'
+        MODEL_DESTROY_PATTERN = /\A(?<model_name>[\w:]+) (Delete|Destroy)\Z/
+
+        # Matches unnamed SQL operations like the following:
+        # "SELECT COUNT(*) FROM `users` ..."
+        MODEL_SQL_PATTERN = /DELETE (?:(DELETE).)* FROM [`"](?<table_name>[^`"]+)[`"]/
+
+        def filter_map(name, sql)
+          match = name.match(MODEL_DESTROY_PATTERN)
+          return ModelName.new(match[:model_name]) if match
+
+          # Fall back to pattern-matching on the table name in a COUNT and looking
+          # up the table name from ActiveRecord's Destroyed descendants.
+          select_from_table = sql.match(MODEL_SQL_PATTERN)
+          TableName.new(select_from_table[:table_name]) if select_from_table
+        end
+      end
+    end
+  end
+end

--- a/spec/ar_query_matchers/mock_data_model.rb
+++ b/spec/ar_query_matchers/mock_data_model.rb
@@ -22,7 +22,7 @@ RSpec.shared_context('mock_data_model') do
         'MockUser'
       end
 
-      has_many :mock_posts
+      has_many :mock_posts, dependent: :destroy
     end
   end
 

--- a/spec/ar_query_matchers/queries/destroy_counter_spec.rb
+++ b/spec/ar_query_matchers/queries/destroy_counter_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# @mission Infrastructure
+# @team DEx
+
+require_relative '../mock_data_model'
+
+RSpec.describe ArQueryMatchers::Queries::DestroyCounter do
+  include_context('mock_data_model')
+
+  it 'does not include reads or creates or updates' do
+    stats = described_class.instrument do
+      MockUser.create!
+      user = MockUser.last
+      user.update(name: 'NEW')
+    end
+
+    expect(stats.query_counts).to be_empty
+  end
+
+  it 'records deletes and destroys' do
+    user_1 = MockUser.create!
+    user_2 = MockUser.create!
+    user_3 = MockUser.create!
+
+    post = MockPost.create!(mock_user: user_1)
+
+    # For a later destroy_all
+    MockPost.create!(mock_user: user_3)
+    MockPost.create!(mock_user: user_3)
+    MockPost.create!(mock_user: user_3)
+
+    stats = described_class.instrument do
+      user_1.destroy
+      # This is implied from dependent destroy, so we're leaving the code here:
+      # post.delete
+
+      user_2.delete
+
+      MockPost.destroy_all
+    end
+
+    expect(stats.query_counts).to eq('MockUser' => 2, 'MockPost' => 4)
+  end
+end


### PR DESCRIPTION
While experimenting with this I figured it'd also be useful to count how many deletions are occurring, especially to make sure we know what's getting modified in rake tasks.