### PR TITLE
Authenticate release workflow to Cloudsmith via OIDC

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -9,21 +9,23 @@ jobs:
   build:
     name: Build + Publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@master
+    - name: Authenticate with Cloudsmith via OIDC
+      uses: cloudsmith-io/cloudsmith-cli-action@v2
+      with:
+        oidc-namespace: "gusto"
+        oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+        oidc-auth-only: "true"
     - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
 
-    - name: Publish to RubyGems
+    - name: Publish to Cloudsmith
       run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
         gem build *.gemspec
-        gem push *.gem
-      env:
-        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+        GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push *.gem --host https://cloudsmith.io/gusto/gusto


### PR DESCRIPTION
## Summary

Migrates the gem-publish workflow from rubygems.org static credentials to Cloudsmith via GitHub OIDC, per the org-wide Cloudsmith migration effort.

- Adds `permissions: id-token: write` at the job level, required to mint the GitHub OIDC token.
- Adds an "Authenticate with Cloudsmith via OIDC" step (`cloudsmith-io/cloudsmith-cli-action@v2`) right after checkout and before Ruby setup. This exchanges the OIDC token for a Cloudsmith token and exports it as `CLOUDSMITH_API_KEY` for later steps.
- Removes the step that wrote `~/.gem/credentials` using `secrets.RUBYGEMS_AUTH_TOKEN`.
- Changes the push command to `GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push *.gem --host https://cloudsmith.io/gusto/gusto` (same `*.gem` glob as before).

Host endpoint `https://cloudsmith.io/gusto/gusto` is the confirmed explicit value for this migration effort.

## Precedent

This exact pattern was already proven in:
- Gusto/virtuous-pdf#452 (merged) — introduced the OIDC auth step + `id-token: write` permission.
- Gusto/fixture_kit#70 (draft, open) — introduced the `GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push ... --host https://cloudsmith.io/gusto/gusto` push step.

## Status

Draft — opening for review, pending a real publish run (tag push) to confirm the Cloudsmith host and push succeed end-to-end.